### PR TITLE
Change urllib.urlencode to urllib.parse.urlencode

### DIFF
--- a/preview.geotiff/geotiffutils.py
+++ b/preview.geotiff/geotiffutils.py
@@ -76,7 +76,7 @@ class Utils:
         if str(prj_code).strip() != 'None':
             return prj_code
 
-        query = urllib.urlencode({'exact':True,'error':True,'mode':'wkt','terms':prj_txt})
+        query = urllib.parse.urlencode({'exact':True,'error':True,'mode':'wkt','terms':prj_txt})
 
         try:
             webres = urllib.urlopen('http://prj2epsg.org/search.json', query.encode())


### PR DESCRIPTION
Python 2: `urllib.urlencode`
Python 3: `urllib.parse.urlencode`

Source: https://stackoverflow.com/questions/60255836/python-3-equivalent-of-python-2-urllib-urlencode

Fixes #15 

NOTE: This may not be the only fix required to remedy this issue, as the stackoverflow post mentions that the return type has changed from bytes to string.