### PR TITLE
Fixing urllib methods that are incompatible with python3

### DIFF
--- a/preview.geoshp/zipshputils.py
+++ b/preview.geoshp/zipshputils.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 import json
 import urllib
+import urllib.parse
 import requests
 from osgeo import osr
 from osgeo import ogr

--- a/preview.geoshp/zipshputils.py
+++ b/preview.geoshp/zipshputils.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 import json
 import urllib
+import requests
 from osgeo import osr
 from osgeo import ogr
 import tempfile
@@ -193,10 +194,10 @@ class Utils:
         if str(prj_code).strip() != 'None':
             return prj_code
 
-        query = urllib.urlencode({'exact':True,'error':True,'mode':'wkt','terms':prj_txt})
+        query = urllib.urlparse.urlencode({'exact':True,'error':True,'mode':'wkt','terms':prj_txt})
 
         try:
-            webres = urllib.urlopen('http://prj2epsg.org/search.json', query.encode())
+            webres = urllib.request.urlopen('http://prj2epsg.org/search.json', query.encode())
             jres = json.loads(webres.read().decode())
             if len(jres['codes']) > 0: 
                 prj_code = jres['codes'][0]['code']

--- a/preview.geoshp/zipshputils.py
+++ b/preview.geoshp/zipshputils.py
@@ -195,7 +195,7 @@ class Utils:
         if str(prj_code).strip() != 'None':
             return prj_code
 
-        query = urllib.urlparse.urlencode({'exact':True,'error':True,'mode':'wkt','terms':prj_txt})
+        query = urllib.parse.urlencode({'exact':True,'error':True,'mode':'wkt','terms':prj_txt})
 
         try:
             webres = urllib.request.urlopen('http://prj2epsg.org/search.json', query.encode())


### PR DESCRIPTION
Adding urllib.parse
and urllib.request
in order to work with python3