### PR TITLE
fixing ex.message by replacing with just debug(ex)

### DIFF
--- a/preview.geoshp/extractor_info.json
+++ b/preview.geoshp/extractor_info.json
@@ -1,7 +1,7 @@
 {
     "@context": "http://clowder.ncsa.illinois.edu/contexts/extractors.jsonld",
     "name": "ncsa.geoshp.preview",
-    "version": "2.1.0",
+    "version": "2.1.1",
     "description": "gepshp extractor takes .zip input file to communicate with geoserver to retrieve WMS metadata",
     "author": "Jong Lee <jonglee1@illinois.edu>",
     "contributors": [

--- a/preview.geoshp/ncsa.geo.shp.py
+++ b/preview.geoshp/ncsa.geo.shp.py
@@ -30,7 +30,7 @@ class ExtractorsGeoshpPreview(Extractor):
         self.extractorName = os.getenv('RABBITMQ_QUEUE', "ncsa.geoshp.preview")
         self.geoServer = os.getenv('GEOSERVER_URL')
         self.gs_username = os.getenv('GEOSERVER_USERNAME', 'admin')
-        self.gs_password = os.getenv('GEOSERVER_PASSWORD', 'geosever')
+        self.gs_password = os.getenv('GEOSERVER_PASSWORD', 'geoserver')
         self.proxy_url = os.getenv('PROXY_URL', 'http://localhost:9000/api/proxy/')
         self.proxy_on = os.getenv('PROXY_ON', 'false')
 
@@ -134,7 +134,7 @@ class ExtractorsGeoshpPreview(Extractor):
                 self.logger.debug("upload previewer")
 
         except Exception as ex:
-            self.logger.debug(ex.message)
+            self.logger.debug(ex)
         finally:
             try:
                 os.remove(tmpfile)


### PR DESCRIPTION
I fixed the line where there is debug(ex.message). Depending on the exception ex does not always have a 'message' field so an error is thrown on the logging in those cases.

Also fixed geosever typo to geoserver.