### PR TITLE
Fixed Shapfile previewer bounding box not created properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.1.2 - 2021-07-21
 ### Fixed
-- Fix the tiff file extension. 
+- Shapfile previewer bounding box not created properly for projections that have their axis
+  reversed. [#23](https://github.com/clowder-framework/extractors-geo/issues/23)
+- Added more labels to extractor_info. [PR#12](https://github.com/clowder-framework/extractors-geo/pull/12)
+- Missing field in catch exception code. [PR#22](https://github.com/clowder-framework/extractors-geo/pull/22)
+
+## 2.1.1 - 2021-10-30
+- Updated extractor to python 3.7. [PR#7](https://github.com/clowder-framework/extractors-geo/pull/7)
+- Fix the tiff file extension. [PR#11](https://github.com/clowder-framework/extractors-geo/pull/11/files)
 
 ## 1.0.2 - 2019-05-29
 ### Fixed

--- a/preview.geoshp/README.md
+++ b/preview.geoshp/README.md
@@ -7,7 +7,14 @@ geoshp extractor takes .zip input file and communicates with GeoServer (https://
       docker build -t clowder/extractors-geoshp-preview .
 
 ## Test the docker container image:
-      docker run --name=geoshp -d --restart=always -e 'RABBITMQ_URI=amqp://user1:pass1@rabbitmq.ncsa.illinois.edu:5672/clowder-dev' -e 'RABBITMQ_EXCHANGE=clowder' -e 'TZ=/usr/share/zoneinfo/US/Central' -e 'REGISTRATION_ENDPOINTS=http://dts-dev.ncsa.illinois.edu:9000/api/extractors?key=key1'  -e 'GEOSERVER_URL=geoserver url' -e 'GEOSERVER_PASSWORD=passwd' -e 'docker exec -it -u bdcli d47316abcb19 bashGEOSERVER_WORKSPACE=testing' -e 'GEOSERVER_USERNAME=username' clowder/extractors-geoshp-preview
+```
+      docker run --name=geoshp-preview -d
+      -e 'GEOSERVER_URL=http://localhost:8080/geoserver/' 
+      -e 'GEOSERVER_PASSWORD={geoserver passwd}' 
+      -e 'GEOSERVER_WORKSPACE=clowder' 
+      -e 'GEOSERVER_USERNAME={geoserver username}' 
+      clowder/extractors-geoshp-preview
+```
 
 ## To run without docker
 
@@ -43,5 +50,10 @@ To install and run the python extractor, do the following:
 6. Start extractor
 
    `./ncsa.geo.shp.py`
+
+## Known Issues
+- The WMS layer might have the wrong bouding box. The layer will be shown on the openlayers previewer but the map will
+  zoom to the wrong spot. We manually reproject the bounding box (see `zipshputils.findExtent()`). Some projections use 
+  reversed axis. For those we use a different formula. The list of projections requiring this is at `zipshputils.findExtent():231`. 
 
 

--- a/preview.geoshp/extractor_info.json
+++ b/preview.geoshp/extractor_info.json
@@ -1,7 +1,7 @@
 {
     "@context": "http://clowder.ncsa.illinois.edu/contexts/extractors.jsonld",
     "name": "ncsa.geoshp.preview",
-    "version": "2.1.0",
+    "version": "2.1.2",
     "description": "gepshp extractor takes .zip input file to communicate with geoserver to retrieve WMS metadata",
     "author": "Jong Lee <jonglee1@illinois.edu>",
     "contributors": [

--- a/preview.geoshp/zipshputils.py
+++ b/preview.geoshp/zipshputils.py
@@ -224,20 +224,34 @@ class Utils:
             self.logger.debug('findExtent: Unknown projection; could not calculate extent')
             return 'None'
 
+        original_epsg = int(self.zipShpProp['epsg'])
+
+        # list of EPSG using reversed axis
+        # TODO mote this to a more central place
+        epsg_reverse_axis = [3413]
+
         shpfile = ogr.Open(self.zipShpProp['shpFile'])
         osrs = osr.SpatialReference()
-        osrs.ImportFromEPSG(int(self.zipShpProp['epsg']))
+        osrs.ImportFromEPSG(original_epsg)
         dsrs = osr.SpatialReference()
         dsrs.ImportFromEPSG(3857) # google projeciton in epsg code
         ct = osr.CoordinateTransformation(osrs, dsrs)
         layer = shpfile.GetLayer(0)
         a = layer.GetExtent()
+        # TODO figure out why we do this
         proj = layer.GetSpatialRef()
         if proj.GetAttrValue("AUTHORITY", 1) == '4326':
             a = self.validateBbox(a)
-        ab = ct.TransformPoint(a[2], a[0],0)
-        cd = ct.TransformPoint(a[3], a[1],0)
-        r= [ab[0], ab[1], cd[0], cd[1]]
+
+        # re-project bounding box based on whether the projection using reversed axis or not
+        if original_epsg in epsg_reverse_axis:
+            ab = ct.TransformPoint(a[0], a[2], 0)
+            cd = ct.TransformPoint(a[1], a[3], 0)
+            r = [cd[0], ab[1], ab[0], cd[1]]
+        else:
+            ab = ct.TransformPoint(a[2], a[0], 0)
+            cd = ct.TransformPoint(a[3], a[1], 0)
+            r = [ab[0], ab[1], cd[0], cd[1]]
 
         return ','.join(map(str,r))
 

--- a/preview.geotiff/README.md
+++ b/preview.geotiff/README.md
@@ -10,7 +10,14 @@ GeoTiff extractor communicates with GeoServer (https://geoserver.ncsa.illinois.e
       docker build -t clowder/extractors-geotiff-preview .
 
 ## Test the docker container image:
-      docker run --name=geotiff-preview -d --restart=always -e 'RABBITMQ_URI=amqp://user1:pass1@rabbitmq.ncsa.illinois.edu:5672/clowder-dev' -e 'RABBITMQ_EXCHANGE=clowder' -e 'TZ=/usr/share/zoneinfo/US/Central' -e 'REGISTRATION_ENDPOINTS=http://dts-dev.ncsa.illinois.edu:9000/api/extractors?key=key1' -e 'GEOSERVER_URL=geoserver url' -e 'GEOSERVER_PASSWORD=passwd' -e 'docker exec -it -u bdcli d47316abcb19 bashGEOSERVER_WORKSPACE=testing' -e 'GEOSERVER_USERNAME=username' clowder/extractors-geotiff-preview
+```
+      docker run --name=geotiff-preview -d
+      -e 'GEOSERVER_URL=http://localhost:8080/geoserver/' 
+      -e 'GEOSERVER_PASSWORD={geoserver passwd}' 
+      -e 'GEOSERVER_WORKSPACE=clowder' 
+      -e 'GEOSERVER_USERNAME={geoserver username}' 
+      clowder/extractors-geotiff-preview
+```
 
 ## To run without docker
 


### PR DESCRIPTION
for projections that have their axis reversed. #23

Updated CHANGELOG and README.

The WMS layer might have the wrong bounding box. The layer will be shown on the openlayers previewer but the map will zoom to the wrong spot. We manually reproject the bounding box (see `zipshputils.findExtent()`). Some projections use reversed axis. For those we use a different formula. The list of projections requiring this is at `zipshputils.findExtent():231`.

I have built it and tested it local with a PDG shapefile and a standard zip file we use for test. Both worked fine. Let me know if you need help testing it.